### PR TITLE
feat: only consider the most recent commit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31196,7 +31196,7 @@ async function main () {
   const majorChanges = []
   const minorChanges = []
   const patchChanges = []
-  for (const commit of commits) {
+  for (const commit of commits.slice(-1)) {
     try {
       const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
       if (bumpTypes.major.includes(cAst.type)) {

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ async function main () {
   const majorChanges = []
   const minorChanges = []
   const patchChanges = []
-  for (const commit of commits) {
+  for (const commit of commits.slice(-1)) {
     try {
       const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
       if (bumpTypes.major.includes(cAst.type)) {


### PR DESCRIPTION
Workaround to avoid bumping the version of a monorepo target based on previous commits.

Only consider the most recent commit found. This will work for us as we're using squash & merge on PRs, and that's the only way change reaches `main`; which the action runs on.