### PR TITLE
fix: check more tags to workaround monorepo issue

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31080,7 +31080,7 @@ async function main () {
     const tagsRaw = await gh.graphql(`
       query lastTags ($owner: String!, $repo: String!) {
         repository (owner: $owner, name: $repo) {
-          refs(first: 10, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
+          refs(first: 100, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
             nodes {
               name
               target {
@@ -31115,7 +31115,7 @@ async function main () {
     }
 
     if (!latestTag) {
-      return core.setFailed(skipInvalidTags ? 'None of the 10 latest tags are valid semver!' : 'Latest tag is invalid (does not conform to semver)!')
+      return core.setFailed(skipInvalidTags ? 'None of the 100 latest tags are valid semver!' : 'Latest tag is invalid (does not conform to semver)!')
     }
 
     core.info(`Comparing against latest tag: ${prefix}${latestTag.name}`)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function main () {
     const tagsRaw = await gh.graphql(`
       query lastTags ($owner: String!, $repo: String!) {
         repository (owner: $owner, name: $repo) {
-          refs(first: 10, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
+          refs(first: 100, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
             nodes {
               name
               target {
@@ -76,7 +76,7 @@ async function main () {
     }
 
     if (!latestTag) {
-      return core.setFailed(skipInvalidTags ? 'None of the 10 latest tags are valid semver!' : 'Latest tag is invalid (does not conform to semver)!')
+      return core.setFailed(skipInvalidTags ? 'None of the 100 latest tags are valid semver!' : 'Latest tag is invalid (does not conform to semver)!')
     }
 
     core.info(`Comparing against latest tag: ${prefix}${latestTag.name}`)


### PR DESCRIPTION
Slack: https://manypets.slack.com/archives/C036GU7GFKR/p1700058643034249

Action failing in monorepo when none of the last 10 tags are for this prefix

i.e. `fe-app-` in below example
![image](https://github.com/boughtbymany/semver-action/assets/1500070/5d2d4af0-f232-4a6e-bc43-3aeb9b3659df)

when all the latest tags are for other prefixes
![image](https://github.com/boughtbymany/semver-action/assets/1500070/821ee9b1-a23b-4417-8671-b367ff4f8570)

This will need addressing; use of this forked action could be replaced with a custom script instead, as we're only using a subset of it's functionality

For now, this will unblock by increasing the number of tags assessed from `10` to, the maximum allowed on the API call, `100`.