### PR TITLE
[Aikido] AI Fix for 3rd party Github Actions should be pinned

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         if: ${{ !env.ACT }}
 
       - name: Get Next Version
@@ -68,7 +68,7 @@ jobs:
       # LOCAL TEST
 
       - name: (local) Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         if: ${{ env.ACT }}
         with:
           path: changelog-action


### PR DESCRIPTION
This patch mitigates a potential supply chain attack by pinning the version of third-party GitHub Actions to their full commit SHA.

Aikido detected these issues via a custom SAST rule. Automated autofix is not available for this custom rule, so this PR was generated using GitHub Copilot (claude-sonnet-4.6) to address all open findings.