### PR TITLE
ci(security): harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -10,6 +13,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+          persist-credentials: false
         if: ${{ !env.ACT }}
 
       - name: Get Next Version
@@ -69,6 +73,7 @@ jobs:
 
       - name: (local) Checkout Code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+          persist-credentials: false
         if: ${{ env.ACT }}
         with:
           path: changelog-action


### PR DESCRIPTION
## Summary

Automated hardening of GitHub Actions workflows to address Aikido SAST findings.

## Automated changes

- `.github/workflows/deploy.yml`
  - added top-level permissions: contents: read
  - added persist-credentials: false to actions/checkout
  - added persist-credentials: false to actions/checkout

## Findings requiring manual review

- **GitHub Action actions/checkout persist Git credentials in workflow** (1 issues)
  - `.github/workflows/deploy.yml`

These remaining findings (template injection, overly broad job permissions, binary downloads, NODE_AUTH_TOKEN usage) require case-by-case review and are not safe to change automatically.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>